### PR TITLE
restored the old relationship classes

### DIFF
--- a/src/Relationship.java
+++ b/src/Relationship.java
@@ -1,0 +1,78 @@
+/**
+ * A class to create a relationship between two other classes
+ * @author Nick Hayes & Lincoln Craddock
+ */
+public class Relationship 
+{
+    private String src;
+    private String dest;
+
+    /**
+     * Relationship constructor
+     * @param src The name of the source of the relationship
+     * @param dest The name of the destination of the relationship
+     */
+    Relationship(String src, String dest)
+    {
+        if(UMLClassHandler.exists(src))
+        {
+            this.src = src;
+        }
+        else
+        {
+            throw new IllegalArgumentException("Source does not exist");
+        }
+        if(UMLClassHandler.exists(dest))
+        {
+            this.dest = dest;
+        }
+        else
+        {
+            throw new IllegalArgumentException("Destination does not exist");
+        }
+    }
+
+    /**
+     * Getter method for the src field
+     * @return The src of the object called upon
+     */
+    String getSrc()
+    {
+        return this.src;
+    }
+
+    /**
+     * Getter method for the dest field
+     * @return The dest of the object called upon
+     */
+    String getDest()
+    {
+        return this.dest;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if(obj != null && obj.getClass() == this.getClass())
+        {
+            Relationship r = (Relationship)obj;
+            if(this.src == r.src && this.dest == r.dest)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override 
+    public String toString()
+    {
+        return this.src + " --> " + this.dest;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return this.src.hashCode() * 5 + this.dest.hashCode() * 7;
+    }
+}    

--- a/src/RelationshipHandler.java
+++ b/src/RelationshipHandler.java
@@ -1,0 +1,31 @@
+import java.util.TreeSet;
+/**
+ * Relationship Handler class to add, delete and get relationships
+ * @author Nick Hayes & Lincoln Craddock
+ */
+public class RelationshipHandler
+{
+    //Tree Set for no duplicates and it is sorted
+    private static TreeSet<Relationship> relationships;
+
+    /**
+     * @throws IllegalArgumentException when trying to add a relationship that already exists
+     * @throws IllegalArgumentException when trying to add a relationship between at least 1 non existing class
+     */
+    static void addRelationship(String src, String dest)
+    {
+        if(UMLClassHandler.exists(src) && UMLClassHandler.exists(dest))
+        {
+            Relationship r = new Relationship(src, dest);
+            if(relationships.contains(r))
+            {
+                throw new IllegalArgumentException("This relationship already exists");
+            }
+            relationships.add(r);
+        }
+        else
+        {
+            throw new IllegalArgumentException("Either the source or destination is invalid");
+        }
+    }
+}

--- a/src/RelationshipTester.java
+++ b/src/RelationshipTester.java
@@ -1,0 +1,91 @@
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A bunch of test cases to make sure the Relationship class works.
+ * 
+ * @author Lincoln Craddock
+ */
+public class RelationshipTester {
+
+    Relationship r;
+    Relationship r2;
+
+    @Before
+    public void setUp()
+    {
+        UMLClassHandler.createClass("Class1");
+        UMLClassHandler.createClass("Class2");
+        UMLClassHandler.createClass("Jeremy");
+        UMLClassHandler.createClass("Jane");
+        r = new Relationship("Class1", "Class2");
+        r2 = new Relationship("Jeremy", "Jane");
+    }
+    
+    @Test
+    public void RelationshipHasCorrectSrc()
+    {
+        assertEquals("The name of the src should be \"Class1\"", "Class1", r.getSrc());
+    }
+    
+    @Test
+    public void RelationshipHasCorrectSrc2()
+    {
+        assertEquals("The name of the src should be \"Jeremy\"", "Jeremy", r2.getSrc());
+    }
+    
+    @Test
+    public void RelationshipHasCorrectDest()
+    {
+        assertEquals("The name of the dest should be \"Class2\"", "Class2", r.getDest());
+    }
+    
+    @Test
+    public void RelationshipHasCorrectDest2()
+    {
+        assertEquals("The name of the dest should be \"Jane\"", "Jane", r2.getDest());
+    }
+    
+    @Test
+    public void RelationshipsAreEqual()
+    {
+        Relationship rCopy = new Relationship("Class1", "Class2");
+        assertTrue("Two relationships between Class1 and Class2 should be equal.", r.equals(rCopy));
+    }
+    
+    @Test
+    public void RelationshipsAreEqual2()
+    {
+        Relationship rCopy = new Relationship("Class1", "Class2");
+        assertTrue("Two relationships between Class1 and Class2 should be equal.", rCopy.equals(r));
+    }
+    
+    @Test
+    public void RelationshipsAreNotEqual()
+    {
+        assertFalse(r + " should not equal " + r2, r.equals(r2));
+    }
+    
+    @Test
+    public void RelationshipsAreNotEqual2()
+    {
+        assertFalse(r2 + " should not equal " + r, r2.equals(r));
+    }
+    
+    @Test
+    public void RelationshipToStringWorks()
+    {
+        assertEquals("The string representation should be \"Class1 --> Class2\"", "Class1 --> Class2", r.toString());
+    }
+    
+    @Test
+    public void RelationshipToStringWorks2()
+    {
+        assertEquals("The string representation should be \"Jeremy --> Jane\"", "Jeremy --> Jane", r2.toString());
+    }
+   
+}


### PR DESCRIPTION
There are a number of problems with these classes:
- They store Strings, but they should probably store Class objects
- The RelationshipHandler uses a TreeSet, but the Relationship class doesn't implement Comparable
- The Relationship class needs to store its "type"

...but it's a good start